### PR TITLE
Updates redirect logic on the /authenticated route with new RFC logic

### DIFF
--- a/pages/authenticated.tsx
+++ b/pages/authenticated.tsx
@@ -21,9 +21,12 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
     // either the `token` cookie didn't exist
     // or token verification failed
     // either way: redirect to the login page
-    ctx.res.writeHead(302, { Location: '/login' });
-    ctx.res.end();
-    return { props: {} as never };
+    return { 
+      redirect: {
+        permanent: false,
+        destination: '/login'
+      }
+    }
   }
 };
 


### PR DESCRIPTION
RFC discussion can be found here: https://github.com/vercel/next.js/discussions/14890

The logic was introduced in Next.js 9.5.4 as an 'unstable feature' but has
recently moved into the canary release.

Recent updates regarding availability:
https://github.com/vercel/next.js/discussions/14890#discussioncomment-112119