### PR TITLE
Allow production cookie usage

### DIFF
--- a/auth.tsx
+++ b/auth.tsx
@@ -18,16 +18,16 @@ export function AuthProvider({ children }: any) {
       if (!user) {
         console.log(`no token found...`);
         setUser(null);
-        nookies.destroy(null, "token");
-        nookies.set(null, "token", "", {path: '/'});
+        nookies.destroy(null, "__session");
+        nookies.set(null, "__session", "", {path: '/'});
         return;
       }
 
       console.log(`updating token...`);
       const token = await user.getIdToken();
       setUser(user);
-      nookies.destroy(null, "token");
-      nookies.set(null, "token", token, {path: '/'});
+      nookies.destroy(null, "__session");
+      nookies.set(null, "__session", token, {path: '/'});
     });
   }, []);
 


### PR DESCRIPTION
Firebase removes cookies when using functions to allow for better CDN optimization, and only allows `__session` to pass through. So it works properly when using the `__session` cookie, while `token` gets deleted.